### PR TITLE
feat: add Docker image building and publishing infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Git
+.git
+.gitignore
+
+# Documentation
+docs/
+*.md
+LICENSE
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Build artifacts
+*.so
+*.dylib
+*.dll
+*.exe
+
+# Test files
+*_test.go
+testdata/
+
+# Temporary files
+*.tmp
+*.temp

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,56 @@
+name: Publish zenjob-api-linter Docker image to GitHub Packages
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/publish-docker.yml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: zenjob/api-linter
+
+jobs:
+  build-and-push-image:
+    runs-on: preprod-s-runner
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Multi-stage build for zenjob-api-linter
+FROM --platform=${BUILDPLATFORM} golang:1.23-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git ca-certificates tzdata
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the binary
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    go build -ldflags '-s -w -extldflags "-static"' -o api-linter ./cmd/api-linter
+
+# Final stage
+FROM alpine:3
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates tzdata
+
+# Set labels
+LABEL org.opencontainers.image.source=https://github.com/zenjob/api-linter
+LABEL org.opencontainers.image.description="Zenjob API Linter with custom rules"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
+# Copy binary from builder stage
+COPY --from=builder /app/api-linter /usr/local/bin/
+
+# Create non-root user
+RUN addgroup -g 10001 -S api-linter && \
+    adduser -u 10001 -S api-linter -G api-linter
+
+# Switch to non-root user
+USER 10001:10001
+
+# Set entrypoint
+ENTRYPOINT ["api-linter"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
+# Zenjob API Linter (Fork of Google API Linter)
+
+## About this Fork
+
+This repository is a Zenjob-maintained fork of the [Google API Linter](https://github.com/googleapis/api-linter). Its purpose is to:
+
+- Add and maintain Zenjob-specific lint rules and organizational customizations.
+- Provide a Docker image and distribution pipeline under the Zenjob namespace.
+- Stay closely in sync with upstream improvements and bugfixes.
+
+> **Note:** We are tracking the upstream discussion for a plugin mechanism in [googleapis/api-linter#1485](https://github.com/googleapis/api-linter/issues/1485). If/when official plugin support is implemented, this fork may be retired in favor of upstream extensibility.
+
+## Keeping the Fork Up to Date
+
+To update this fork with the latest changes from upstream:
+
+1. Add the upstream remote if not already present:
+
+   ```sh
+   git remote add upstream https://github.com/googleapis/api-linter.git
+   ```
+
+2. Fetch upstream changes:
+
+   ```sh
+   git fetch upstream
+   ```
+
+3. Rebase or merge upstream/main into your working branch:
+
+   ```sh
+   git checkout main
+   git merge upstream/main
+   # or: git rebase upstream/main
+   ```
+
+4. Resolve any conflicts, test, and push changes to the Zenjob fork.
+
+---
+
 # Google API Linter
 
 [![ci](https://github.com/googleapis/api-linter/actions/workflows/ci.yaml/badge.svg)](https://github.com/googleapis/api-linter/actions/workflows/ci.yaml)


### PR DESCRIPTION
## Description

This PR adds Docker image building and publishing infrastructure to the zenjob-api-linter fork, moving the capability from the third-party docker-api-linter repository into our organization.

## Changes

- **Dockerfile**: Multi-stage build that compiles from local source code (not remote repository)
- **.dockerignore**: Optimized to exclude unnecessary files while allowing source code
- **GitHub Actions Workflow**: Builds and publishes to ghcr.io/zenjob/api-linter using Zenjob's custom runner
- **README.md**: Added fork description and upstream sync guide

## Key Features

- Builds from local source code (includes any custom rules we add)
- Uses Zenjob's preprod-s-runner for consistent builds
- Publishes with proper tagging (latest, branch, tag, PR)
- Includes artifact attestation for provenance
- Follows Zenjob's Docker conventions

## Testing

- Docker build tested locally and validated
- Image size: ~35.7MB (optimized)
- Binary functionality verified

## Next Steps

Once merged, the supply project can be updated to use ghcr.io/zenjob/api-linter instead of the third-party image.